### PR TITLE
Forgotten release plugín

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,4 +6,6 @@ addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.18.0")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.3.2")
 
+addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.3")
+
 addSbtPlugin("edu.gemini" % "sbt-gsp" % "0.2.5")


### PR DESCRIPTION
I removed this thinking it would come with `sbt-gsp` but we need to include explicitly.