### PR TITLE
Use doubles to avoid an error if -0 appears

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,13 +4,13 @@ lazy val reactJS                = "17.0.2"
 lazy val scalaJsReact           = "2.0.1"
 lazy val lucumaCoreVersion      = "0.28.0"
 lazy val lucumaUIVersion        = "0.30.2"
-lazy val aladinLiteVersion      = "0.6.1"
+lazy val aladinLiteVersion      = "0.6.2"
 lazy val reactCommonVersion     = "0.14.8"
 lazy val reactGridLayoutVersion = "0.14.2"
 lazy val munitVersion           = "0.7.29"
 lazy val svgdotjsVersion        = "0.2.1"
 
-ThisBuild / tlBaseVersion       := "0.16"
+ThisBuild / tlBaseVersion       := "0.17"
 ThisBuild / tlCiReleaseBranches := Seq("master")
 
 Global / onChangedBuildSource := ReloadOnSourceChanges

--- a/demo/src/main/scala/react/aladin/package.scala
+++ b/demo/src/main/scala/react/aladin/package.scala
@@ -72,11 +72,11 @@ package aladin {
   trait JsMouseMoved extends js.Object {
     val ra: Double
     val dec: Double
-    val x: Int
-    val y: Int
+    val x: Double
+    val y: Double
   }
 
-  final case class MouseMoved(ra: RightAscension, dec: Declination, x: Int, y: Int)
+  final case class MouseMoved(ra: RightAscension, dec: Declination, x: Double, y: Double)
 
   object MouseMoved   {
     def fromJs(p: JsMouseMoved): MouseMoved =


### PR DESCRIPTION
Sometimes we see an error on mouse event. I tracked this to sometimes the screen coordinates are "-0" which scala.js wants to convert to double